### PR TITLE
fix: add a check for database name on ensure

### DIFF
--- a/adapters/arangodb/src/adapter.ts
+++ b/adapters/arangodb/src/adapter.ts
@@ -198,7 +198,7 @@ export class ArangoAdapter extends AdapterBase {
         if (
             this.collections.find(
                 c =>
-                    c.database === modelInfo.database &&
+                    (c.database != null && c.database === modelInfo.database) &&
                     c.name === modelInfo.table,
             ) == null
         ) {

--- a/adapters/arangodb/src/adapter.ts
+++ b/adapters/arangodb/src/adapter.ts
@@ -191,11 +191,11 @@ export class ArangoAdapter extends AdapterBase {
 
     protected async ensureTable(ctor: ModelCtor<any>): Promise<void> {
         const modelInfo = Model.getInfo(ctor);
-        const dbName = modelInfo.database || (<string>this.defaultDatabase);
 
-        const collection = this.db(dbName).collection(
+        const collection = this.db(modelInfo.database).collection(
             modelInfo.table,
         );
+        const dbName = modelInfo.database || this.defaultDatabase;
         if (
             this.collections.find(
                 c =>

--- a/adapters/arangodb/src/adapter.ts
+++ b/adapters/arangodb/src/adapter.ts
@@ -191,11 +191,11 @@ export class ArangoAdapter extends AdapterBase {
 
     protected async ensureTable(ctor: ModelCtor<any>): Promise<void> {
         const modelInfo = Model.getInfo(ctor);
+        const dbName = modelInfo.database || (<string>this.defaultDatabase);
 
-        const collection = this.db(modelInfo.database).collection(
+        const collection = this.db(dbName).collection(
             modelInfo.table,
         );
-        const dbName = modelInfo.database || this.defaultDatabase;
         if (
             this.collections.find(
                 c =>

--- a/adapters/arangodb/src/adapter.ts
+++ b/adapters/arangodb/src/adapter.ts
@@ -199,7 +199,7 @@ export class ArangoAdapter extends AdapterBase {
         if (
             this.collections.find(
                 c =>
-                    c.database == dbName &&
+                    c.database === dbName &&
                     c.name === modelInfo.table,
             ) == null
         ) {

--- a/adapters/arangodb/src/adapter.ts
+++ b/adapters/arangodb/src/adapter.ts
@@ -195,10 +195,11 @@ export class ArangoAdapter extends AdapterBase {
         const collection = this.db(modelInfo.database).collection(
             modelInfo.table,
         );
+        const dbName = modelInfo.database || this.defaultDatabase;
         if (
             this.collections.find(
                 c =>
-                    (c.database != null && c.database === modelInfo.database) &&
+                    c.database == dbName &&
                     c.name === modelInfo.table,
             ) == null
         ) {


### PR DESCRIPTION
This adds a small check that the database name is even set. As the Model is typed as a `Partial` meaning it's _optional_ the check here fails each time and thus tries to make a new DB but then errors as it's already made.